### PR TITLE
Update unifi_controller.py

### DIFF
--- a/lib/check_mk/base/plugins/agent_based/unifi_controller.py
+++ b/lib/check_mk/base/plugins/agent_based/unifi_controller.py
@@ -271,7 +271,7 @@ register.inventory_plugin(
 def discovery_unifi_device(section):
     yield Service(item="Device Status")
     yield Service(item="Unifi Device")
-    yield Service(item="Uptime")
+    yield Service(item="Unifi Device Uptime")
     yield Service(item="Active-User")
     if  section.type != "uap":  # kein satisfaction bei ap .. radio/ssid haben schon
         yield Service(item="Satisfaction")
@@ -317,7 +317,7 @@ def check_unifi_device(item,section):
             )
         yield Metric("user_sta",_active_user)
         yield Metric("guest_sta",_safe_int(section.guest_num_sta))
-    if item == "Uptime":
+    if item == "Unifi Device Uptime":
         _uptime = int(section.uptime) if section.uptime else -1
         if _uptime > 0:
             yield Result(


### PR DESCRIPTION
Changed Uptime to Unifi Device Uptime because it collides with the service Uptime if you use SNMP monitoring  additionally on unifi devices.