### PR TITLE
Ensure upcoming checkmk 2.2.0 compatibility

### DIFF
--- a/lib/check_mk/base/plugins/agent_based/unifi_controller.py
+++ b/lib/check_mk/base/plugins/agent_based/unifi_controller.py
@@ -270,7 +270,6 @@ register.inventory_plugin(
 def discovery_unifi_device(section):
     yield Service(item="Device Status")
     yield Service(item="Unifi Device")
-    yield Service(item="Unifi Device Uptime")
     yield Service(item="Active-User")
     if  section.type != "uap":  # kein satisfaction bei ap .. radio/ssid haben schon
         yield Service(item="Satisfaction")
@@ -316,14 +315,7 @@ def check_unifi_device(item,section):
             )
         yield Metric("user_sta",_active_user)
         yield Metric("guest_sta",_safe_int(section.guest_num_sta))
-    if item == "Unifi Device Uptime":
-        _uptime = int(section.uptime) if section.uptime else -1
-        if _uptime > 0:
-            yield Result(
-                state=State.OK,
-                summary=render.timespan(_uptime)
-            )
-            yield Metric("unifi_uptime",_uptime)
+
     if item == "Satisfaction":
         yield Result(
             state=State.OK,
@@ -415,7 +407,7 @@ register.inventory_plugin(
 
 ############ DEVICEPORT ###########
 @dataclass
-class unifi_interface(interfaces.Interface):
+class unifi_interface(interfaces.InterfaceWithCounters):
     jumbo           : bool = False
     satisfaction    : int = 0
     poe_enable      : bool = False
@@ -430,8 +422,6 @@ class unifi_interface(interfaces.Interface):
     ip_address      : Optional[str] = None
     portconf        : Optional[str] = None
 
-    def __post_init__(self) -> None:
-        self.finalize()
 
 def _convert_unifi_counters_if(section: Section) -> interfaces.Section:
     ##  10|port_idx|10
@@ -488,25 +478,29 @@ def _convert_unifi_counters_if(section: Section) -> interfaces.Section:
 
     return [ 
         unifi_interface(
-            index=str(netif.port_idx),
-            descr=netif.name,
-            alias=netif.name,
-            type='6',
-            speed=_safe_int(netif.speed)*1000000,
-            oper_status=netif.oper_status,
-            admin_status=netif.admin_status,
-            in_octets=_safe_int(netif.rx_bytes),
-            in_ucast=_safe_int(netif.rx_packets),
-            in_mcast=_safe_int(netif.rx_multicast),
-            in_bcast=_safe_int(netif.rx_broadcast),
-            in_discards=_safe_int(netif.rx_dropped),
-            in_errors=_safe_int(netif.rx_errors),
-            out_octets=_safe_int(netif.tx_bytes),
-            out_ucast=_safe_int(netif.tx_packets),
-            out_mcast=_safe_int(netif.tx_multicast),
-            out_bcast=_safe_int(netif.tx_broadcast),
-            out_discards=_safe_int(netif.tx_dropped),
-            out_errors=_safe_int(netif.tx_errors),
+            attributes=interfaces.Attributes(
+                index=str(netif.port_idx),
+                descr=netif.name,
+                alias=netif.name,
+                type='6',
+                speed=_safe_int(netif.speed)*1000000,
+                oper_status=netif.oper_status,
+                admin_status=netif.admin_status,
+            ),
+            counters=interfaces.Counters(
+                in_octets=_safe_int(netif.rx_bytes),
+                in_ucast=_safe_int(netif.rx_packets),
+                in_mcast=_safe_int(netif.rx_multicast),
+                in_bcast=_safe_int(netif.rx_broadcast),
+                in_disc=_safe_int(netif.rx_dropped),
+                in_err=_safe_int(netif.rx_errors),
+                out_octets=_safe_int(netif.tx_bytes),
+                out_ucast=_safe_int(netif.tx_packets),
+                out_mcast=_safe_int(netif.tx_multicast),
+                out_bcast=_safe_int(netif.tx_broadcast),
+                out_disc=_safe_int(netif.tx_dropped),
+                out_err=_safe_int(netif.tx_errors),
+            ),
             jumbo=True if netif.jumbo == "1" else False,
             satisfaction=_safe_int(netif.satisfaction) if netif.satisfaction and netif.oper_status == "1" else 0,
             poe_enable=True if netif.poe_enable == "1" else False,
@@ -540,7 +534,7 @@ def check_unifi_network_port_if(  ##fixme parsed_section_name
     section: Section,
 ) -> CheckResult:
     _converted_ifs = _convert_unifi_counters_if(section)
-    iface = next(filter(lambda x: _safe_int(item,-1) == _safe_int(x.index) or item == x.alias,_converted_ifs),None) ## fix Service Discovery appearance alias/descr
+    iface = next(filter(lambda x: _safe_int(item,-1) == _safe_int(x.attributes.index) or item == x.attributes.alias,_converted_ifs),None) ## fix Service Discovery appearance alias/descr
     yield from interfaces.check_multiple_interfaces(
         item,
         params,

--- a/share/check_mk/agents/special/agent_unifi_controller
+++ b/share/check_mk/agents/special/agent_unifi_controller
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
 ##  MIT License
-##  
+##
 ##  Copyright (c) 2021 Bash Club
-##  
+##
 ##  Permission is hereby granted, free of charge, to any person obtaining a copy
 ##  of this software and associated documentation files (the "Software"), to deal
 ##  in the Software without restriction, including without limitation the rights
 ##  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ##  copies of the Software, and to permit persons to whom the Software is
 ##  furnished to do so, subject to the following conditions:
-##  
+##
 ##  The above copyright notice and this permission notice shall be included in all
 ##  copies or substantial portions of the Software.
-##  
+##
 ##  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ##  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ##  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,8 +22,8 @@
 ##  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ##  SOFTWARE.
 
-### 
-__VERSION__ = 0.88
+###
+__VERSION__ = 2.2.0
 
 import sys
 import socket
@@ -214,7 +214,7 @@ class unifi_network_ssid(unifi_object):
 
 ########################################
 ######
-######      R A D I O 
+######      R A D I O
 ######
 ########################################
 class unifi_network_radio(unifi_object):
@@ -233,7 +233,7 @@ class unifi_network_radio(unifi_object):
                 continue
             _ret.append(f"{self.name}|{_k}|{_v}")
         return "\n".join(_ret)
-        
+
 ########################################
 ######
 ######      P O R T
@@ -253,9 +253,9 @@ class unifi_network_port(unifi_object):
                 self.name = self.ifname
         if not hasattr(self,"port_idx") and hasattr(self,"ifname"):
             self.port_idx = int(self.ifname[-1])+1  ## ethX
-        
+
         self.portconf = self._PARENT._PARENT._PORTCONFIGS.get(getattr(self,"portconf_id",None))
-        
+
 
     def _get_state(self,state):
         return {
@@ -286,7 +286,7 @@ class unifi_device(unifi_object):
         self._NETWORK_PORTS = []
         self._NETWORK_RADIO = []
         self._NETWORK_SSIDS = []
-        
+
         for _k,_v in getattr(self,"sys_stats",{}).items():
             _k = _k.replace("-","_")
             setattr(self,_k,_v)
@@ -295,7 +295,7 @@ class unifi_device(unifi_object):
             ## change ip to local ip
             self.wan_ip = self.ip
             self.ip = self.connect_request_ip
-        
+
         if getattr(self,"speedtest_status_saved",False):
             _speedtest = getattr(self,"speedtest_status",{})
             self.speedtest_time = int(_speedtest.get("rundate","0"))
@@ -303,11 +303,11 @@ class unifi_device(unifi_object):
             self.speedtest_ping = round(_speedtest.get("latency",-1),1)
             self.speedtest_download = round(_speedtest.get("xput_download",0.0),1)
             self.speedtest_upload = round(_speedtest.get("xput_upload",0.0),1)
-        
+
         _temp = list(map(lambda x: x.get("value",0),getattr(self,"temperatures",[])))
         if _temp:
             self.general_temperature = "{0:.1f}".format(mean(_temp))
-        
+
         for _port in getattr(self,"port_table",[]):
             self._NETWORK_PORTS.append(unifi_network_port(_PARENT=self,**_port))
 
@@ -370,7 +370,7 @@ class unifi_device(unifi_object):
             _ret += ["","<<<unifi_network_ports:sep(124)>>>"] + [str(_port) for _port in self._NETWORK_PORTS]
         if self._NETWORK_RADIO:
             _ret += ["","<<<unifi_network_radios:sep(124)>>>"] + [str(_radio) for _radio in self._NETWORK_RADIO]
-        
+
         if self._NETWORK_SSIDS:
             _ret += ["","<<<unifi_network_ssids:sep(124)>>>"] + [str(_ssid) for _ssid in sorted(self._NETWORK_SSIDS,key=lambda x: x.essid)]
         return "\n".join(_ret)
@@ -390,7 +390,7 @@ class unifi_site(unifi_object):
                     continue
                 #print(f"{_k}:{_v}")
                 setattr(self,f"{_name}_{_k}",_v)
-        
+
         ##pprint(_api.get_data("/stat/rogueap"))
         self._SITE_DEVICES = []
         self._PORTCONFIGS = {}
@@ -470,13 +470,13 @@ class unifi_controller(unifi_object):
         _dict = defaultdict(list)
         for _ssid in self._UNIFI_SSIDS:
             _dict[f"{_ssid.essid}@{_ssid._UNIFI_SITE.desc}"].append(_ssid)
-        
+
         _ret = []
         for _ssid,_obj in _dict.items():
             #pprint(_obj)
             for _key in ("num_sta","ng_num_sta","na_num_sta","ng_tcp_packet_loss","na_tcp_packet_loss","ng_wifi_retries","na_wifi_retries","ng_wifi_latency","na_wifi_latency"):
                 _ret.append("|".join([_ssid,_key,str(sum(map(lambda x: getattr(x,_key,0),_obj)))]))
-            
+
             _signals = list(map(lambda x: getattr(x,"ng_avg_client_signal",0),filter(lambda x: x.radio == "ng",_obj)))
             _ret.append("|".join([_ssid,"ng_avg_client_signal",str(mean(_signals if _signals else [0]))]))
             _signals = list(map(lambda x: getattr(x,"na_avg_client_signal",0),filter(lambda x: x.radio == "na",_obj)))
@@ -488,7 +488,7 @@ class unifi_controller(unifi_object):
             )]))
             _ret.append("|".join([_ssid,"avg_client_signal",str(mean(map(lambda x: getattr(x,"avg_client_signal",0),_obj))) ]))
         return _ret 
-        
+
     def __str__(self):
         _ret = ["<<<unifi_controller:sep(124)>>>"]
         for _k,_v in self.__dict__.items():
@@ -515,7 +515,7 @@ class unifi_controller(unifi_object):
             if _device._piggy_back:
                 _ret.append(_device._get_short_info())
         ## device list
-        
+
         ## ssid list
         _ret.append("<<<unifi_ssid_list:sep(124)>>>")
         _ret += self._get_ssidlist()


### PR DESCRIPTION
This change makes this special_agent compatible with the upcoming 2.2.0 release of Checkmk.
Unfortunately the required changes make it incompatible with versions prior to 2.2.0.

Hence, I suggest changing the version number to 2.0.0 following Checkmk's versioning and I also suggest building & uploading a new mkp version for 2.2.0 to exchange.checkmk.com afterwards.