### PR TITLE
Update agent_unifi_controller: handle device names

### DIFF
--- a/share/check_mk/agents/special/agent_unifi_controller
+++ b/share/check_mk/agents/special/agent_unifi_controller
@@ -337,7 +337,7 @@ class unifi_device(unifi_object):
 
     def __str__(self):
         if self._piggy_back:
-            _piggybackname = getattr(self,self._API.PIGGYBACK_ATTRIBUT,self.name)
+            _piggybackname = getattr(self,self._API.PIGGYBACK_ATTRIBUT,self.name).replace(" ", "_")
             _ret = [f"<<<<{_piggybackname}>>>>"]
         else:
             _ret = []


### PR DESCRIPTION
UniFi UI allows people to create device names with blanks - of course these don't end up as valid hostnames.

This is a very simplistic fix that replaces blanks with underscores. It allows for piggyback processing of the devices.